### PR TITLE
feat: define the canRun method and write its logic

### DIFF
--- a/process/can_run.go
+++ b/process/can_run.go
@@ -1,0 +1,10 @@
+package process
+
+func (p *Process) CanRun(stocks map[string]int) bool {
+	for resource, required := range p.Needs {
+		if available, ok := stocks[resource]; !ok || available < required {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
### Summary

This pull request implements the `CanRun` method for the `Process` struct.
It enables the engine to check whether a given process can be executed based on the currently available stock.

Closes #7 