### PR TITLE
Feature/implement run method

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -9,3 +9,8 @@ type Engine struct {
 	Cycle           int
 	OptimizeTargets []string
 }
+
+// Stock represents the available items and their quantities.
+type Stock struct {
+	Items map[string]int
+}

--- a/process/run.go
+++ b/process/run.go
@@ -1,0 +1,21 @@
+package process
+
+import (
+	"github.com/jesee-kuya/stock_exchange/engine"
+)
+
+func (p *engine.Process) Run(stocks map[string]int, pending map[int]map[string]int, currentCycle int) {
+    // Deduct input items from the stock
+    for item, requiredQty := range p.Input {
+        stocks[item] -= requiredQty
+    }
+
+    // Schedule output items to be added after process.Cycle duration
+    dueCycle := currentCycle + p.Cycle
+    if pending[dueCycle] == nil {
+        pending[dueCycle] = make(map[string]int)
+    }
+    for item, producedQty := range p.Output {
+        pending[dueCycle][item] += producedQty
+    }
+}


### PR DESCRIPTION
This PR contains an implementation of Run method:

- The method has a signature func (p *engine.Process) Run(stocks map[string]int, pending map[int]map[string]int, currentCycle int).
- It deducts input items from the current stock and schedules output items to be added after the process's Cycle duration.
- This ensures outputs are not applied immediately, preserving the simulation's temporal accuracy.
closes #8 