### PR TITLE
feat: Added NewEngine constructor method

### DIFF
--- a/engine/new_engine.go
+++ b/engine/new_engine.go
@@ -1,0 +1,14 @@
+package engine
+
+import "github.com/jesee-kuya/stock_exchange/process"
+
+// NewEngine creates and initializes a new Engine instance.
+func NewEngine() *Engine {
+	return &Engine{
+		Stock:           &Stock{Items: make(map[string]int)},
+		Processes:       []*process.Process{},
+		Schedule:        []string{},
+		Cycle:           0,
+		OptimizeTargets: []string{},
+	}
+}


### PR DESCRIPTION
This PR introduces the NewEngine function, which serves as a constructor for the Engine struct.

- The method has a signature func NewEngine() *Engine. 
- It initializes all the necessary fields to their default starting values and returns a pointer to the new Engine instance.

Closes #15 